### PR TITLE
Image linking; styling changes; navbar "refresh"

### DIFF
--- a/socialapp/src/components/Navbar/SideNavBar.css
+++ b/socialapp/src/components/Navbar/SideNavBar.css
@@ -78,7 +78,7 @@ hr {
 
 /* Create Post Button */
 
-#sidebar .nav-item {
+#sidebar .side-nav-item {
     align-self: center;
 }
 
@@ -101,7 +101,23 @@ hr {
     cursor: pointer;
 }
 
-.nav-link:hover, .nav-link:focus {
-    color: var(--orange);
+.side-nav-link {
+    width: 50px;
+    height: 50px;
+    padding: 0.5rem 0.5rem;
+    margin: 0.5rem 0.5rem;
+    border-radius: 11px;
+}
+
+.side-nav-link:hover {
     cursor: pointer;
+    background: var(--slightly-darker-blue);
+    transition: background-color 0.5s ease-in-out;
+    border-radius: 11px;
+}
+
+.side-nav-link:hover svg {
+    color: var(--teal) !important;
+    transition: color 0.2s ease-in-out;
+    
 }

--- a/socialapp/src/components/Navbar/SideNavBar.css
+++ b/socialapp/src/components/Navbar/SideNavBar.css
@@ -98,7 +98,10 @@ hr {
 }
 
 .create-post-button:hover {
-    
     cursor: pointer;
 }
 
+.nav-link:hover, .nav-link:focus {
+    color: var(--orange);
+    cursor: pointer;
+}

--- a/socialapp/src/components/Navbar/SideNavBar.jsx
+++ b/socialapp/src/components/Navbar/SideNavBar.jsx
@@ -16,20 +16,17 @@ export default function Sidebar() {
     const refreshState = (navigate, location) => {
         navigate(`${location.pathname}`, {state: {refresh:true}});
     }
-    console.log(location.pathname);
     return (
         <ul
             id="sidebar"
             className="nav nav-pills nav-flush flex-column mb-auto text-center"
         >
-            <li className="nav-item">
+            <li className="side-nav-item">
          
                 <div  
                     className="create-post-button"
                     aria-current="page"
                     title="Create Post"
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="right"
                     onClick={() => setNewPost(true)}
                 >
                     <MdEdit />
@@ -37,34 +34,31 @@ export default function Sidebar() {
                 {newPost && <CreatePost show={newPost} onHide={() => {setNewPost(false); refreshState(navigate, location);}}/>}
 
             </li>
-            <li>
-                <div onClick={() => navigate("/stream", {state: {refresh:true}})}>
-                    <div
-                        className="nav-link py-3"
-                        title="Stream"
-                    >
-                        <FaHome style={{ color: location.pathname === "/stream" || location.pathname === "/" }}/>
-                    </div>
+            <li className="side-nav-item">
+                <div
+                    className="side-nav-link"
+                    title="Stream"
+                    onClick={() => navigate("/stream", {state: {refresh:true}})}
+                >
+                    <FaHome style={{ color: location.pathname === "/stream" ? "var(--orange)" : "var(--white-teal)" }}/>
                 </div>
             </li>
-            <li>
-                <div onClick={() => navigate("/inbox", {state: {refresh:true}})}>
-                    <div
-                        className="nav-link py-3"
-                        title="Inbox"
-                    >
-                        <FaInbox style={{ color: location.pathname === "/inbox" }}/>
-                    </div>
+            <li className="side-nav-item">
+                <div
+                    className="side-nav-link"
+                    title="Inbox"
+                    onClick={() => navigate("/inbox", {state: {refresh:true}})}
+                >
+                    <FaInbox style={{ color: location.pathname === "/inbox" ? "var(--orange)" : "var(--white-teal)" }}/>
                 </div>
             </li>
-            <li>
-                <div onClick={() => navigate("/explore", {state: {refresh:true}})}>
-                    <div
-                        className="nav-link py-3"
-                        title="Explore"
-                    >
-                        <FaSearch style={{ color: location.pathname === "/explore" }}/>
-                    </div>
+            <li className="side-nav-item">
+                <div
+                    className="side-nav-link"
+                    title="Explore"
+                    onClick={() => navigate("/explore", {state: {refresh:true}})}
+                >
+                    <FaSearch style={{ color: location.pathname === "/explore" ? "var(--orange)" : "var(--white-teal)" }}/>
                 </div>
             </li>
             <hr className="solid" />

--- a/socialapp/src/components/Navbar/SideNavBar.jsx
+++ b/socialapp/src/components/Navbar/SideNavBar.jsx
@@ -10,14 +10,13 @@ import CreatePost from "../Posts/CreatePost";
 export default function Sidebar() {
     const { logoutUser } = useContext(AuthContext);
     const [newPost, setNewPost] = useState(false);
-    
     const navigate = useNavigate();
     const location = useLocation();
 
     const refreshState = (navigate, location) => {
         navigate(`${location.pathname}`, {state: {refresh:true}});
     }
-
+    console.log(location.pathname);
     return (
         <ul
             id="sidebar"
@@ -39,43 +38,34 @@ export default function Sidebar() {
 
             </li>
             <li>
-                <Link to="/stream">
-                    <a
-                        href="/"
+                <div onClick={() => navigate("/stream", {state: {refresh:true}})}>
+                    <div
                         className="nav-link py-3"
                         title="Stream"
-                        data-bs-toggle="tooltip"
-                        data-bs-placement="right"
                     >
-                        <FaHome />
-                    </a>
-                </Link>
+                        <FaHome style={{ color: location.pathname === "/stream" || location.pathname === "/" }}/>
+                    </div>
+                </div>
             </li>
             <li>
-                <Link to="/inbox">
-                    <a
-                        href="/"
+                <div onClick={() => navigate("/inbox", {state: {refresh:true}})}>
+                    <div
                         className="nav-link py-3"
                         title="Inbox"
-                        data-bs-toggle="tooltip"
-                        data-bs-placement="right"
                     >
-                        <FaInbox />
-                    </a>
-                </Link>
+                        <FaInbox style={{ color: location.pathname === "/inbox" }}/>
+                    </div>
+                </div>
             </li>
             <li>
-                <Link to="/explore">
-                    <a
-                        href="/"
+                <div onClick={() => navigate("/explore", {state: {refresh:true}})}>
+                    <div
                         className="nav-link py-3"
                         title="Explore"
-                        data-bs-toggle="tooltip"
-                        data-bs-placement="right"
                     >
-                        <FaSearch />
-                    </a>
-                </Link>
+                        <FaSearch style={{ color: location.pathname === "/explore" }}/>
+                    </div>
+                </div>
             </li>
             <hr className="solid" />
             <div className="signout">

--- a/socialapp/src/components/Navbar/TopNavbar.css
+++ b/socialapp/src/components/Navbar/TopNavbar.css
@@ -21,6 +21,7 @@
 #profilePicContainer:hover {
     outline: solid var(--teal) 5px;
     cursor: pointer;
+    transition: outline 0.2s ease-in-out;
 }
 
 .navbar-expand .navbar-nav .nav-link {

--- a/socialapp/src/components/Posts/CreatePost.css
+++ b/socialapp/src/components/Posts/CreatePost.css
@@ -39,32 +39,39 @@
     text-align: left;
 }
 
+.create-post-modal .form-control {
+    box-shadow: none;
+}
+
 
 .create-post-modal .unlist {
     background: transparent;
     border: none;
-    color: #BFEFE9;
-    margin-left: 1%;
-    margin-right: 1%;
-    font-size: 85%;
+    color: var(--teal);
+    font-size: 0.8rem;
+    border-radius: 2rem;
+    padding: 0rem 1rem;
 }
 
 .create-post-modal .header {
-    margin: 0px auto;
+    margin-right: 1rem;
 }
 
 .create-post-modal .header1 {
-    width: 40%;
-    font-size: 110%;
-    margin-top: 1%;
-    margin-right: -10%;
+    width: fit-content;
+    font-size: 1.1rem;
+    margin-right: 2rem;
+    align-self: center;
 }
 
 .create-post-modal .option {
     background: transparent;
     border: none;
-    color: #BFEFE9;
-    font-size: 85%;
+    color: var(--teal);
+    font-size: 0.8rem;
+    border-radius: 2rem;
+    padding: 0rem 1rem;
+    margin-right: 0.2rem;
 }
 
 .create-post-modal .radio input {

--- a/socialapp/src/components/Posts/CreatePost.css
+++ b/socialapp/src/components/Posts/CreatePost.css
@@ -151,8 +151,21 @@
     margin-top: 1rem;
 }
 
+.create-post-modal .link-icon {
+    width: 2.5rem;
+    height:auto;
+    padding: 0rem 0.5rem;
+    color: var(--teal);
+}
+
+.create-post-modal .link-icon:hover {
+    cursor: pointer;
+    color: var(--teal-alt);
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
+}
+
 .create-post-modal .image-upload {
-    width: 3rem;
+    width: 2.8rem;
     height:auto;
     padding: 0rem 0.5rem;
     color: var(--teal);
@@ -176,4 +189,8 @@
     background-color: var(--orange);
     outline: none;
     border: none;
+}
+
+.create-post-modal .link-form {
+    margin-top: 1rem;
 }

--- a/socialapp/src/components/Posts/CreatePost.jsx
+++ b/socialapp/src/components/Posts/CreatePost.jsx
@@ -9,7 +9,7 @@ import {
 import useAxios from "../../utils/useAxios";
 import "./CreatePost.css";
 import AuthContext from "../../context/AuthContext";
-import { FaImage } from "react-icons/fa";
+import { FaImage, FaLink } from "react-icons/fa";
 
 export default function CreatePost(props) {
   const [showURI, setShowURI] = useState(false);
@@ -21,6 +21,7 @@ export default function CreatePost(props) {
   const api = useAxios();
   const user_id = localStorage.getItem("user_id");
   const [imagePost, setImagePost] = useState(null);
+  const [showLinkForm, setShowLinkForm] = useState(false);
   const [uri, setURI] = useState("");
   const [post, setPost] = useState({
     title: "",
@@ -180,6 +181,7 @@ export default function CreatePost(props) {
     const file = e.target.files[0];
     if (reader !== undefined && file !== undefined) {
       reader.onloadend = () => {
+        setShowLinkForm(false);
         setFile(file);
         setSize(file.size);
         setFileName(file.name);
@@ -206,12 +208,21 @@ export default function CreatePost(props) {
     setFileName("");
     setSize("");
     setImagePost(null);
+    setPost({ ...post, image: "" });
   };
 
   const hiddenFileInput = React.useRef(null);
   const handleImageClick = () => {
     hiddenFileInput.current.click();
   };
+
+  const linkClickHandler = () => {
+    setShowLinkForm(!showLinkForm);
+    setImagePreview("");
+    delete post.image;
+    setPost(post);
+    setImagePost(null);
+  }
 
   return (
     <>
@@ -333,6 +344,21 @@ export default function CreatePost(props) {
                   Please choose a walk type.
                 </Form.Control.Feedback>
               </Form.Group>
+              {showLinkForm && <Form.Group className="link-form">
+                <Form.Control
+                  label="link"
+                  name="link"
+                  type="text"
+                  placeholder="Image URL link"
+                  onChange={(e) => {
+                    setPost({
+                      ...post,
+                      image: e.target.value,
+                    });
+                    setImagePreview(e.target.value);
+                  }}
+                />
+              </Form.Group>}
             </Modal.Body>
             {imagePreview === "" ? (
               <></>
@@ -359,14 +385,16 @@ export default function CreatePost(props) {
                     style={{ display: "none" }}
                   />
                 </form>
-                {imagePreview === "" ? (
-                  <></>
-                ) : (
+                {imagePost ? (
                   <Button className="remove-image" onClick={removeImage}>
                     Remove Image
                   </Button>
+                ) : (
+                  <></>
                 )}
+                <FaLink className="link-icon" onClick={() => linkClickHandler()}/>
               </div>
+              
               <Button className="postButton" onClick={sendPost}>
                 Post
               </Button>

--- a/socialapp/src/components/Posts/CreatePost.jsx
+++ b/socialapp/src/components/Posts/CreatePost.jsx
@@ -44,7 +44,11 @@ export default function CreatePost(props) {
 
   const setVisibility = (option) => {
     setPost({ ...post, visibility: option });
-    setImagePost({ ...imagePost, visiblity: option });
+
+    // only set the visibility for imagePost if there is an image
+    if (imagePost) {
+      setImagePost({ ...imagePost, visiblity: option });
+    }
     if (option === "PUBLIC") {
       setEveActive(true);
       setFriActive(false);
@@ -87,6 +91,7 @@ export default function CreatePost(props) {
 
   const sendPost = async () => {
     // No image
+    console.log("ImagePost", imagePost);
     if (!imagePost) {
       api
         .post(`${baseURL}/authors/${user_id}/posts/`, post)
@@ -101,7 +106,7 @@ export default function CreatePost(props) {
           }
         })
         .catch((error) => {
-          alert(`Something went wrong posting! \n Error: ${error}`);
+          alert(`Something went wrong posting! \n Error: ${error.response.data}`);
           console.log(error);
         });
     } else {
@@ -131,7 +136,7 @@ export default function CreatePost(props) {
         })
         .catch((error) => {
           alert(
-            `Something went wrong posting the image post! \n Error: ${error.response}`
+            `Something went wrong posting the image post! \n Error: ${error.response.data}`
           );
           console.log(error.response);
         });

--- a/socialapp/src/components/Posts/EditPost.jsx
+++ b/socialapp/src/components/Posts/EditPost.jsx
@@ -8,7 +8,7 @@ import {
 import useAxios from "../../utils/useAxios";
 import "./CreatePost.css";
 import AuthContext from "../../context/AuthContext";
-import { FaImage } from "react-icons/fa";
+import { FaImage, FaLink } from "react-icons/fa";
 
 export default function EditPost(props) {
   const [showURI, setShowURI] = useState(false);
@@ -29,20 +29,13 @@ export default function EditPost(props) {
   const user_id = localStorage.getItem("user_id");
   const [imagePost, setImagePost] = useState(null);
   const [uri, setURI] = useState("");
-  // const [post, setPost] = useState({
-  //     title: props.post.title,
-  //     source: props.post.source,
-  //     origin: props.post.origin,
-  //     description: props.post.description,
-  //     contentType: props.post.contentType,
-  //     content: props.post.content,
-  //     categories: props.post.categories,
-  //     visibility: props.post.visibility,
-  //     unlisted: props.post.unlisted,
-  // });
   const propsPost = props.post;
   delete propsPost.commentSrc; // causing issue with updating.
   const [post, setPost] = useState(propsPost);
+  const [showLinkForm, setShowLinkForm] = useState(() =>
+    props.post.image ? true : false
+  );
+
 
   /**
    * In order to change the color of the button when selecting a visibility option, whenever the user clicks on one of the options,
@@ -200,6 +193,7 @@ export default function EditPost(props) {
     const file = e.target.files[0];
     if (reader !== undefined && file !== undefined) {
       reader.onloadend = () => {
+        setShowLinkForm(false);
         setFile(file);
         setSize(file.size);
         setFileName(file.name);
@@ -226,13 +220,21 @@ export default function EditPost(props) {
     setFileName("");
     setSize("");
     setImagePost(null);
-    setPost({ ...post, image: null });
+    setPost({ ...post, image: "" });
   };
 
   const hiddenFileInput = React.useRef(null);
   const handleImageClick = () => {
     hiddenFileInput.current.click();
   };
+
+  const linkClickHandler = () => {
+    setShowLinkForm(!showLinkForm);
+    setImagePreview("");
+    delete post.image;
+    setPost(post);
+    setImagePost(null);
+  }
 
   return (
     <>
@@ -356,6 +358,22 @@ export default function EditPost(props) {
                   Please choose a walk type.
                 </Form.Control.Feedback>
               </Form.Group>
+              {showLinkForm && <Form.Group className="link-form">
+                <Form.Control
+                  label="link"
+                  name="link"
+                  type="text"
+                  placeholder="Image URL link"
+                  value={post.image}
+                  onChange={(e) => {
+                    setPost({
+                      ...post,
+                      image: e.target.value,
+                    });
+                    setImagePreview(e.target.value);
+                  }}
+                />
+              </Form.Group>}
             </Modal.Body>
             {imagePreview === null ? (
               <></>
@@ -389,6 +407,7 @@ export default function EditPost(props) {
                     Remove Image
                   </Button>
                 )}
+                <FaLink className="link-icon" onClick={() => linkClickHandler()}/>
               </div>
               <Button className="postButton" onClick={postIsSame}>
                 Post

--- a/socialapp/src/components/Posts/EditPost.jsx
+++ b/socialapp/src/components/Posts/EditPost.jsx
@@ -54,7 +54,9 @@ export default function EditPost(props) {
 
   const setVisibility = (option) => {
     setPost({ ...post, visibility: option });
-    setImagePost({ ...imagePost, visiblity: option });
+    if (imagePost) {
+      setImagePost({ ...imagePost, visiblity: option });
+    }
     if (option === "PUBLIC") {
       setEveActive(true);
       setFriActive(false);

--- a/socialapp/src/components/Posts/ExplorePostCard.css
+++ b/socialapp/src/components/Posts/ExplorePostCard.css
@@ -17,8 +17,8 @@
 }
 
 .post-card-explore .profile-pic-post {
-    width: 3em;
-    height: 3em;
+    width: 2em;
+    height: 2em;
     aspect-ratio: 1/1;
     border-radius: 80%;
     outline: solid var(--orange) 2px;
@@ -33,7 +33,7 @@
     display: inline-flex;
     align-items: center;
     gap: 1rem;
-
+    color: var(--teal);
 }
 
 .post-card-explore .post-author-name {

--- a/socialapp/src/components/Posts/ExplorePostCard.css
+++ b/socialapp/src/components/Posts/ExplorePostCard.css
@@ -1,9 +1,11 @@
 .post-card-explore {
     width: 20rem;
-    height: 18rem;
+    height: fit-content;
+    max-height: 22rem;
     margin-block: 10px;
     margin-left: 10px;
     border-color: none;
+    --bs-card-bg: none;
 }
 
 .post-card-explore .card-header {
@@ -11,7 +13,7 @@
     align-items: center;
     background-color: var(--slightly-darker-blue);
     box-shadow: rgb(0 0 0 / 16%) 1px 1px 10px;
-
+    border-radius: 11px 11px 0px 0px;
 }
 
 .post-card-explore .profile-pic-post {
@@ -49,7 +51,7 @@
     background-color: var(--dark-blue);
     box-shadow: rgb(0 0 0 / 16%) 1px 1px 10px;
     border: transparent;
-    border-radius: 0px 0px 2px 2px;
+    border-radius: 0px 0px 11px 11px;
     overflow: hidden;
 }
 
@@ -80,6 +82,10 @@
 
 .post-card-explore .comments-text {
     color: var(--teal);
+}
+
+.post-card-explore .dropdown-toggle::after {
+    content: none;
 }
 
 .post-card-explore .options {
@@ -127,4 +133,26 @@
 
 .options .dropdown-item {
     padding: 0.8em var(--bs-dropdown-item-padding-x);
+}
+
+.post-card-explore .like-icon {
+    transition-duration: 300ms;
+    transition-property: color, transform;
+    transition-timing-function: ease-in-out;
+    width: 2rem;
+    height: auto;
+    padding: 0.5rem;
+}
+
+.post-card-explore .like-icon:hover {
+    color: var(--teal) !important;
+    cursor: pointer;
+    transition: color 0.2s ease-in-out, background-color 0.5s ease-in-out;
+    background-color: var(--slightly-darker-blue);
+    border-radius: 11px;
+}
+
+.post-card-explore .like-icon:active {
+    color: var(--orange) !important;
+    transform: rotate(10deg);
 }

--- a/socialapp/src/components/Posts/ExplorePostCard.jsx
+++ b/socialapp/src/components/Posts/ExplorePostCard.jsx
@@ -238,14 +238,14 @@ export default function PostCard(props) {
                   style={{
                     background: "none",
                     border: "none",
-                    "margin-left": "auto",
+                    marginLeft: "auto",
                     padding: "0.5rem",
                     width: "2rem",
                     height: "2rem",
                   }}
                 >
                   <BsCursorFill
-                    style={{ color: "var(--white-teal)", "vertical-align": "top" }}
+                    style={{ color: "var(--white-teal)", verticalAlign: "top" }}
                     onClick={postRouteChange}
                   />
                 </button>
@@ -256,10 +256,10 @@ export default function PostCard(props) {
               mouseLeaveDelay={300}
               mouseEnterDelay={0}
               arrow={true}
-              contentStyle={{ "background-color": "var(--dark-blue)", border: "none", width: "fit-content", padding: "0.5em" }}
-              arrowStyle={{ "color": "var(--dark-blue)", stroke: "none" }}
+              contentStyle={{ backgroundColor: "var(--dark-blue)", border: "none", width: "fit-content", padding: "0.5em" }}
+              arrowStyle={{ color: "var(--dark-blue)", stroke: "none" }}
             >
-              <span style={{ "font-size": "0.8rem"}}> View Post </span>
+              <span style={{ fontSize: "0.8rem"}}> View Post </span>
             </Popup>
           </Col>
         </Row>

--- a/socialapp/src/components/Posts/ExplorePostCard.jsx
+++ b/socialapp/src/components/Posts/ExplorePostCard.jsx
@@ -27,7 +27,7 @@ export default function PostCard(props) {
   const [color, setColor] = useState("var(--white-teal)");
   const [author, setAuthor] = useState("");
   const [followers, setFollowers] = useState([]);
-
+  
   const navigate = useNavigate();
   const routeChange = () => {
     navigate(`/authors/${post_user_id}/`, { state: { refresh: true } });
@@ -126,23 +126,22 @@ export default function PostCard(props) {
   };
 
   const sharePost = (post) => {
-    console.log(post.id)
-    for(let index = 0; index < followers.length; index++) {
-      const sharedPost = {
-        type: "post",
-        summary: `${author.displayName} shared a post.`,
-        author: author,
-        object: post.id,
-      };
-      api
-        .post(`${baseURL}/authors/${followers[index].uuid}/inbox/`, post)
-        .then((response) => {
-          console.log(response)
-        })
-        .catch((error) => {
-          console.log("Failed to get posts of author. " + error);
-        });
-    }
+      for(let index = 0; index < followers.length; index++) {
+        const sharedPost = {
+          type: "post",
+          summary: `${author.displayName} shared a post.`,
+          author: author,
+          object: post.id,
+        };
+        api
+          .post(`${baseURL}/authors/${followers[index].uuid}/inbox/`, post)
+          .then((response) => {
+            console.log(response)
+          })
+          .catch((error) => {
+            console.log("Failed to get posts of author. " + error);
+          });
+      }
   };
 
   // only render options if the user viewing it is the author of it

--- a/socialapp/src/components/Posts/ExplorePostCard.jsx
+++ b/socialapp/src/components/Posts/ExplorePostCard.jsx
@@ -24,7 +24,7 @@ export default function PostCard(props) {
   const api = useAxios();
   const [likeCount, setLikeCount] = useState(0);
   const [CommentCount, setCommentCount] = useState(0);
-  const [color, setColor] = useState("white");
+  const [color, setColor] = useState("var(--white-teal)");
   const [author, setAuthor] = useState("");
   const [followers, setFollowers] = useState([]);
 
@@ -225,24 +225,27 @@ export default function PostCard(props) {
           <Col>
             <div>
               <BsFillHeartFill
-                style={{ color: likeCount != 0 ? "var(--orange)" : "white" }}
+                className="like-icon"
+                style={{ color: likeCount !== 0 ? "var(--orange)" : "var(--white-teal)" }}
                 onClick={() => sendPostLike(props.post.uuid)}
               />
             </div>
           </Col>
-          <Col>
+          <Col style={{ display: "flex", height: "fit-content" }}>
             <Popup
               trigger={
                 <button
                   style={{
                     background: "none",
                     border: "none",
-                    right: "10px",
-                    position: "absolute",
+                    "margin-left": "auto",
+                    padding: "0.5rem",
+                    width: "2rem",
+                    height: "2rem",
                   }}
                 >
                   <BsCursorFill
-                    style={{ color: "white" }}
+                    style={{ color: "var(--white-teal)", "vertical-align": "top" }}
                     onClick={postRouteChange}
                   />
                 </button>
@@ -253,8 +256,10 @@ export default function PostCard(props) {
               mouseLeaveDelay={300}
               mouseEnterDelay={0}
               arrow={true}
+              contentStyle={{ "background-color": "var(--dark-blue)", border: "none", width: "fit-content", padding: "0.5em" }}
+              arrowStyle={{ "color": "var(--dark-blue)", stroke: "none" }}
             >
-              <span> Click for details! </span>
+              <span style={{ "font-size": "0.8rem"}}> View Post </span>
             </Popup>
           </Col>
         </Row>

--- a/socialapp/src/components/Posts/PostCard.css
+++ b/socialapp/src/components/Posts/PostCard.css
@@ -88,6 +88,20 @@
     color: var(--teal);
 }
 
+.post-card .friends-indicator {
+    display: inline-flex;
+    align-items: center;
+    margin-left: auto;
+    margin-right: 1rem;
+    gap: 0.5rem;
+    background-color: var(--dark-blue);
+    border-radius: 2.5rem;
+    font-size: 0.9rem;
+    font-family: 'Readex Pro Light';
+    padding: 0.3rem 1rem;
+    color: var(--teal);
+}
+
 .post-card .options {
     display: inline-block;
     white-space: nowrap;

--- a/socialapp/src/components/Posts/PostCard.css
+++ b/socialapp/src/components/Posts/PostCard.css
@@ -10,7 +10,7 @@
     align-items: center;
     background-color: var(--slightly-darker-blue);
     box-shadow: rgb(0 0 0 / 16%) 1px 1px 10px;
-    
+    border: 2px solid var(--dark-blue);
 }
 
 .post-card .profile-pic-post {

--- a/socialapp/src/components/Posts/PostCard.css
+++ b/socialapp/src/components/Posts/PostCard.css
@@ -48,6 +48,7 @@
     padding: 1em;
     width: 100%;
     white-space: pre-line;
+    font-family: "Readex Pro Light";
 }
 
 .post-card > .card-body {
@@ -165,18 +166,24 @@
 .post-card .like-comment-container {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.1rem;
 }
+
 .post-card .like-comment-container > .like-icon {
     transition-duration: 300ms;
     transition-property: color, transform;
     transition-timing-function: ease-in-out;
+    width: 2rem;
+    height: auto;
+    padding: 0.5rem;
 }
 
 .post-card .like-comment-container > .like-icon:hover {
     color: var(--teal) !important;
     cursor: pointer;
-    transition: color 0.2s ease-in-out;
+    transition: color 0.2s ease-in-out, background-color 0.5s ease-in-out;
+    background-color: var(--slightly-darker-blue);
+    border-radius: 11px;
 }
 
 .post-card .like-comment-container > .like-icon:active {
@@ -184,8 +191,37 @@
     transform: rotate(10deg);
 }
 
+.post-card .like-comment-container > .comment-icon {
+    width: 2rem;
+    height: auto;
+    padding: 0.5rem;
+}
+
 .post-card .like-comment-container > .comment-icon:hover {
     color: var(--teal) !important;
     cursor: pointer;
-    transition: color 0.2s ease-in-out;
+    transition: color 0.2s ease-in-out, background-color 0.5s ease-in-out;
+    background-color: var(--slightly-darker-blue);
+    border-radius: 11px;
+}
+
+.post-card .like-comment-container > .share-icon {
+    color: var(--white-teal);
+    margin-left: 1rem;
+    width: 2rem;
+    height: auto;
+    padding: 0.4rem;
+}
+
+.post-card .like-comment-container > .share-icon:hover {
+    color: var(--teal) !important;
+    cursor: pointer;
+    transition: color 0.2s ease-in-out, background-color 0.5s ease-in-out;
+    background-color: var(--slightly-darker-blue);
+    border-radius: 11px;
+}
+
+.post-card .like-comment-container > .share-icon:active {
+    color: var(--orange) !important;
+    transform: rotate(10deg);
 }

--- a/socialapp/src/components/Posts/PostCard.jsx
+++ b/socialapp/src/components/Posts/PostCard.jsx
@@ -32,6 +32,8 @@ export default function PostCard(props) {
   const [author, setAuthor] = useState("");
   const [open, openComments] = useState(false);
   const [followers, setFollowers] = useState([]);
+  const [friends, setFriends] = useState([]);
+
   // if the post is an image post, don't show it's content,
   // since it contains a base64 string. Which is very long.
   const [showContent, setShowContent] = useState(() => {
@@ -118,27 +120,55 @@ export default function PostCard(props) {
         .catch((error) => {
           console.log(error);
         });
+      await api
+        .get(
+          `${baseURL}/authors/${user_id}/friends/`
+        )
+        .then((response) => {
+          setFriends(response.data.items)})
+        .catch((error) => {
+          console.log(error);
+        });
     };
     fetchData();
   }, []);
 
   const sharePost = (post) => {
     console.log(post.id)
-    for(let index = 0; index < followers.length; index++) {
-      const sharedPost = {
-        type: "post",
-        summary: `${author.displayName} shared a post.`,
-        author: author,
-        object: post.id,
-      };
-      api
-        .post(`${baseURL}/authors/${followers[index].uuid}/inbox/`, post)
-        .then((response) => {
-          console.log(response)
-        })
-        .catch((error) => {
-          console.log("Failed to get posts of author. " + error);
-        });
+    if (post.visibility === "PUBLIC") {
+      for(let index = 0; index < followers.length; index++) {
+        const sharedPost = {
+          type: "post",
+          summary: `${author.displayName} shared a post.`,
+          author: author,
+          object: post.id,
+        };
+        api
+          .post(`${baseURL}/authors/${followers[index].uuid}/inbox/`, post)
+          .then((response) => {
+            console.log(response)
+          })
+          .catch((error) => {
+            console.log("Failed to get posts of author. " + error);
+          });
+      }
+    } else if (post.visibility === "FRIENDS") {
+      for(let index = 0; index < friends.length; index++) {
+        const sharedPost = {
+          type: "post",
+          summary: `${author.displayName} shared a post.`,
+          author: author,
+          object: post.id,
+        };
+        api
+          .post(`${baseURL}/authors/${friends[index].uuid}/inbox/`, post)
+          .then((response) => {
+            console.log(response)
+          })
+          .catch((error) => {
+            console.log("Failed to get posts of author. " + error);
+          });
+      }
     }
   };
 

--- a/socialapp/src/components/Posts/PostCard.jsx
+++ b/socialapp/src/components/Posts/PostCard.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Dropdown, InputGroup, Form, Button, Container } from "react-bootstrap";
 import { BiDotsVerticalRounded } from "react-icons/bi";
-import { MdModeEdit, MdDelete } from "react-icons/md";
+import { MdModeEdit, MdDelete, MdShare } from "react-icons/md";
 import { IoUnlink } from "react-icons/io5";
 import Card from "react-bootstrap/Card";
 import AuthContext from "../../context/AuthContext";
@@ -30,6 +30,7 @@ export default function PostCard(props) {
   const [color, setColor] = useState("white");
   const [author, setAuthor] = useState("");
   const [open, openComments] = useState(false);
+  const [followers, setFollowers] = useState([]);
   // if the post is an image post, don't show it's content,
   // since it contains a base64 string. Which is very long.
   const [showContent, setShowContent] = useState(() => {
@@ -107,9 +108,38 @@ export default function PostCard(props) {
         .catch((error) => {
           console.log(error);
         });
+      await api
+        .get(
+          `${baseURL}/authors/${user_id}/followers`
+        )
+        .then((response) => {
+          setFollowers(response.data.items)})
+        .catch((error) => {
+          console.log(error);
+        });
     };
     fetchData();
   }, []);
+
+  const sharePost = (post) => {
+    console.log(post.id)
+    for(let index = 0; index < followers.length; index++) {
+      const sharedPost = {
+        type: "post",
+        summary: `${author.displayName} shared a post.`,
+        author: author,
+        object: post.id,
+      };
+      api
+        .post(`${baseURL}/authors/${followers[index].uuid}/inbox/`, post)
+        .then((response) => {
+          console.log(response)
+        })
+        .catch((error) => {
+          console.log("Failed to get posts of author. " + error);
+        });
+    }
+  };
 
   const deletePost = (uuid) => {
     api
@@ -268,6 +298,8 @@ export default function PostCard(props) {
             onClick={() => openComments(!open)}
           />
           {comments.length}
+
+          <MdShare className="share-icon" onClick={() => sharePost(props.post)}/>
         </div>
         <div>
           {open ? (

--- a/socialapp/src/components/Posts/PostCard.jsx
+++ b/socialapp/src/components/Posts/PostCard.jsx
@@ -4,6 +4,7 @@ import { Dropdown, InputGroup, Form, Button, Container } from "react-bootstrap";
 import { BiDotsVerticalRounded } from "react-icons/bi";
 import { MdModeEdit, MdDelete, MdShare } from "react-icons/md";
 import { IoUnlink } from "react-icons/io5";
+import { FaUserFriends } from "react-icons/fa";
 import Card from "react-bootstrap/Card";
 import AuthContext from "../../context/AuthContext";
 import "./PostCard.css";
@@ -247,13 +248,28 @@ export default function PostCard(props) {
             {props.post.author.displayName}
           </div>
         </div>
+        {props.post.visibility === "FRIENDS" ? (
+          <div className="friends-indicator">
+            <FaUserFriends />
+            Friends-Only
+          </div>
+        ) : (
+          <div className="friends-indicator" style={{ background: "none" }} />
+        )}
         {props.post.unlisted === true ? (
-          <div className="unlisted-indicator">
+          <div className="unlisted-indicator" style={{
+            margin: props.post.visibility === "FRIENDS" ? "0 1rem 0 0" : "0 1rem 0 auto"
+          }}>
             <IoUnlink />
             Unlisted
           </div>
         ) : (
-          <div className="unlisted-indicator" style={{ background: "none" }} />
+          <div className="unlisted-indicator" style={{ 
+            background: "none",
+            margin: "0",
+            padding: "0" 
+            }} 
+          />
         )}
         <PostOptions />
         {showEditPost && (

--- a/socialapp/src/custom_dark.scss
+++ b/socialapp/src/custom_dark.scss
@@ -81,11 +81,6 @@ $font-family-base: "Readex Pro" !important;
   --bs-nav-pills-link-active-bg: var(--teal-alt);
 }
 
-.main .nav-link {
-  color: var(--white-teal);
-  transition: color .15s ease-in-out,background-color .15s ease-in-out,var(--teal) .15s ease-in-out
-}
-
 
 // Move main page (where stream/inbox/explore pages are going to be) to the right...due to issues with sidebar
 .main .main-content-container {

--- a/socialapp/src/custom_dark.scss
+++ b/socialapp/src/custom_dark.scss
@@ -86,10 +86,6 @@ $font-family-base: "Readex Pro" !important;
   transition: color .15s ease-in-out,background-color .15s ease-in-out,var(--teal) .15s ease-in-out
 }
 
-.main .nav-link:hover, .main .nav-link:focus {
-  color: var(--orange);
-}
-
 
 // Move main page (where stream/inbox/explore pages are going to be) to the right...due to issues with sidebar
 .main .main-content-container {

--- a/socialapp/src/pages/Explore.css
+++ b/socialapp/src/pages/Explore.css
@@ -13,6 +13,7 @@
     position: relative;
     margin-left: -2em;
     z-index: 2;
+    border-radius: 11px;
 }
 
 .FaSearch {

--- a/socialapp/src/pages/Explore.css
+++ b/socialapp/src/pages/Explore.css
@@ -1,3 +1,7 @@
+.explore-title-container {
+    padding-bottom: 1rem;
+}
+
 .search-bar-explore {
     padding: 0.5em 3em;
     width: 20em;
@@ -7,22 +11,32 @@
     border: none;
     border-bottom: solid 1px var(--orange);
     position: relative;
+    margin-left: -2em;
+    z-index: 2;
 }
 
 .FaSearch {
     color: var(--teal);
-    margin-left: 0em;
+    margin-left: -em;
+    height: 1em;
+    width: 1em;
+    z-index: 3;
+}
+
+.search-col {
     display: flex;
     align-items: center;
-    height: 2em;
-    width: 2em;
+}
 
+.authors-explore-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .search-bar-explore:focus {
     outline: none !important;
-    border: solid 3px var(--orange);
-
+    background: var(--dark-blue);
 }
 
 .custom {

--- a/socialapp/src/pages/Explore.jsx
+++ b/socialapp/src/pages/Explore.jsx
@@ -12,6 +12,7 @@ import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import Container from "react-bootstrap/Container";
+import { useLocation } from "react-router-dom";
 
 function RenderAuthors(props) {
   // given the list of authors from the query, creates the user cards
@@ -57,7 +58,7 @@ export default function Explore() {
       .catch((error) => {
         console.log(error);
       });
-  }, []);
+  }, [useLocation().state]);
 
   const search = async (val) => {
     setLoading(true);

--- a/socialapp/src/pages/Explore.jsx
+++ b/socialapp/src/pages/Explore.jsx
@@ -23,9 +23,9 @@ function RenderAuthors(props) {
             props.authors.items.map((author) => <UserCard author={author} key={author.id}/>)
           ) : (
             <Card style={{ backgroundColor: "var(--darker-blue)" }}>
-              <h1 style={{ marginLeft: "15px" }}>
+              <h5 style={{ marginLeft: "15px" }}>
                 No match result for authors!
-              </h1>
+              </h5>
             </Card>
           )
         ) : null}
@@ -99,11 +99,12 @@ export default function Explore() {
   return (
     <Container>
       {/* Stack the columns on mobile by making one full-width and the other half-width */}
-      <Row>
+      <Row className="explore-title-container">
         <Col>
           <h1>Explore</h1>
         </Col>
-        <Col>
+        <Col className="search-col">
+          <FaSearch className="FaSearch" />
           <input
             className="search-bar-explore"
             value={value}
@@ -111,9 +112,7 @@ export default function Explore() {
             placeholder="Search for an author/post"
           />
         </Col>
-        <Col>
-          <FaSearch className="FaSearch" />
-        </Col>
+        <Col className="empty-rec" />
       </Row>
       <div className="searchResult">
         {value !== "" ? <RenderAuthors authors={authors} /> : null}
@@ -136,7 +135,7 @@ export default function Explore() {
                 </Row>
               </>
             ) : (
-              <h1> No match result for posts!</h1>
+              <h5> No match result for posts!</h5>
             )
           ) : (
             <>

--- a/socialapp/src/pages/Inbox.css
+++ b/socialapp/src/pages/Inbox.css
@@ -18,3 +18,19 @@
     font-family: "Readex Pro Bold";
     color: var(--dark-blue);
 }
+
+.inbox-items-container .nav-item {
+    margin-right: 0.5rem;
+}
+
+.inbox-items-container .nav-item .nav-link {
+    outline: 2px solid var(--dark-blue);
+    --bs-nav-link-hover-color: var(--teal);
+    --bs-nav-link-color: var(--white-teal);
+    border-radius: 11px;
+}
+
+.inbox-items-container .nav-item .nav-link:hover {
+    background: var(--dark-blue);
+    transition: background-color 0.2s ease-in-out;
+}   

--- a/socialapp/src/pages/Inbox.css
+++ b/socialapp/src/pages/Inbox.css
@@ -1,0 +1,20 @@
+.react-confirm-alert-overlay {
+    background: rgba(28, 33, 43, 0.8);
+}
+
+.react-confirm-alert-body {
+    background: var(--dark-blue);
+    color: var(--teal);
+}
+
+.react-confirm-alert-button-group .yes-button {
+    background-color: var(--teal);
+    font-family: "Readex Pro Bold";
+    color: var(--dark-blue);
+}
+
+.react-confirm-alert-button-group .no-button {
+    background-color: var(--orange);
+    font-family: "Readex Pro Bold";
+    color: var(--dark-blue);
+}

--- a/socialapp/src/pages/Inbox.jsx
+++ b/socialapp/src/pages/Inbox.jsx
@@ -59,7 +59,7 @@ export default function Inbox() {
               }
             } else if (response.data.items[i].type.toLowerCase() === "post") {
               setPostNum((postNum) => postNum + 1);
-              setPosts((posts) => [...posts, response.data.items[i]]);
+              setPosts((posts) => [response.data.items[i], ...posts]);
             }
           }
 
@@ -117,7 +117,7 @@ export default function Inbox() {
               <div>
                 <BsFillTrashFill
                   style={{
-                    color: "white",
+                    color: "var(--orange)",
                     marginTop: "1em",
                     marginBottom: "1em",
                     marginRight: "1em",
@@ -126,13 +126,13 @@ export default function Inbox() {
                 />
               </div>
             }
-            position="bottom center"
+            position="right center"
             on="hover"
             closeOnDocumentClick
-            contentStyle={{ padding: "0px", border: "none", color: "black" }}
-            arrow={true}
+            contentStyle={{ padding: "0.5rem", "background-color": "var(--dark-blue)", border: "none", width: "fit-content" }}
+            arrowStyle={{ color: "var(--dark-blue)", stroke: "none" }}
           >
-            <span> Click to clear inbox! </span>
+            <span> Clear Inbox </span>
           </Popup>
         </Col>
       </Row>
@@ -170,10 +170,10 @@ export default function Inbox() {
                     posts.length !== 0 ? (
                       posts.map((item, i) => <PostCard post={item} key={i}/>)
                     ) : (
-                      <h4>No post yet! </h4>
+                      <h4>No posts yet! </h4>
                     )
                   ) : (
-                    <h4>No post yet! </h4>
+                    <h4>No posts yet! </h4>
                   )}
                 </Tab.Pane>
                 <Tab.Pane eventKey="like">
@@ -194,23 +194,23 @@ export default function Inbox() {
                         <InboxCommentCard comment={item} key={i}/>
                       ))
                     ) : (
-                      <h4>No comment yet! </h4>
+                      <h4>No comments yet! </h4>
                     )
                   ) : (
-                    <h4>No comment yet! </h4>
+                    <h4>No comments yet! </h4>
                   )}
                 </Tab.Pane>
                 <Tab.Pane eventKey="follow">
                   {typeof followRequests !== "undefined" ? (
                     followRequests.length !== 0 ? (
                       followRequests.map((item, i) => (
-                        <FollowRequestCard followRequest={item} kley={i}/>
+                        <FollowRequestCard followRequest={item} key={i}/>
                       ))
                     ) : (
-                      <h4>No follow request yet! </h4>
+                      <h4>No follow requests yet! </h4>
                     )
                   ) : (
-                    <h4>No follow request yet! </h4>
+                    <h4>No follow requests yet! </h4>
                   )}
                 </Tab.Pane>
               </Tab.Content>
@@ -223,7 +223,7 @@ export default function Inbox() {
           <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
           <strong className="me-auto">Bootstrap</strong>
         </Toast.Header>
-        <Toast.Body>You successfully delet inbox!</Toast.Body>
+        <Toast.Body>Cleared inbox successfully</Toast.Body>
       </Toast>
     </div>
   );

--- a/socialapp/src/pages/Inbox.jsx
+++ b/socialapp/src/pages/Inbox.jsx
@@ -15,6 +15,8 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Toast from "react-bootstrap/Toast";
 import Nav from "react-bootstrap/Nav";
+import "./Inbox.css";
+
 export default function Inbox() {
   const [inboxItems, setInboxItems] = useState([]);
   const [posts, setPosts] = useState([]);
@@ -73,14 +75,15 @@ export default function Inbox() {
 
   const clearInbox = () => {
     confirmAlert({
-      title: "Confirm to delete",
-      message: "Are you sure to clear inbox?",
+      title: "Clear inbox?",
       buttons: [
         {
           label: "Yes",
+          className: "yes-button",
           onClick: () => deleteInbox(),
         },
         {
+          className: "no-button",
           label: "No",
         },
       ],

--- a/socialapp/src/pages/Inbox.jsx
+++ b/socialapp/src/pages/Inbox.jsx
@@ -157,7 +157,7 @@ export default function Inbox() {
             <Row>
               <Nav
                 variant="pills"
-                id="justify-tab-example"
+                id="inbox-tab-row"
                 justify
                 fill
               >

--- a/socialapp/src/pages/Inbox.jsx
+++ b/socialapp/src/pages/Inbox.jsx
@@ -15,16 +15,16 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Toast from "react-bootstrap/Toast";
 import Nav from "react-bootstrap/Nav";
+import { useLocation } from "react-router-dom";
 import "./Inbox.css";
 
 export default function Inbox() {
   const [inboxItems, setInboxItems] = useState([]);
   const [posts, setPosts] = useState([]);
   const [postNum, setPostNum] = useState(0);
-  const [likeNum, setlikeNum] = useState(0);
+  const [likeNum, setLikeNum] = useState(0);
   const [commentNum, setCommentNum] = useState(0);
   const [followNum, setFollowNum] = useState(0);
-
   const [followRequests, setFollowRequests] = useState([]);
   const [likes, setLikes] = useState([]);
   const [comments, setComments] = useState([]);
@@ -38,6 +38,17 @@ export default function Inbox() {
       await api
         .get(`${baseURL}/authors/${user_id}/inbox/all`)
         .then((response) => {
+          // Since clicking inbox icon in sidebar recalls this function,
+          // all these states need to be reset, otherwise one could
+          // infinitely click on inbox to add a lot duplicate posts/likes/etc.
+          setPostNum(0);
+          setLikeNum(0);
+          setCommentNum(0);
+          setFollowNum(0);
+          setPosts([]);
+          setLikes([]);
+          setComments([]);
+          setFollowRequests([]);
           setInboxItems(response.data.items);
           for (let i = 0; i < response.data.items.length; i++) {
             if (response.data.items[i].type.toLowerCase() === "follow") {
@@ -47,7 +58,7 @@ export default function Inbox() {
                 response.data.items[i],
               ]);
             } else if (response.data.items[i].type.toLowerCase() === "like") {
-              setlikeNum((likeNum) => likeNum + 1);
+              setLikeNum((likeNum) => likeNum + 1);
               setLikes((likes) => [...likes, response.data.items[i]]);
             } else if (
               response.data.items[i].type.toLowerCase() === "comment"
@@ -71,7 +82,7 @@ export default function Inbox() {
         });
     };
     fetchData();
-  }, []);
+  }, [useLocation().state]);
 
   const clearInbox = () => {
     confirmAlert({
@@ -99,7 +110,7 @@ export default function Inbox() {
         setLikes([]),
         setFollowRequests([]),
         setPostNum(0),
-        setlikeNum(0),
+        setLikeNum(0),
         setCommentNum(0),
         setFollowNum(0),
       )

--- a/socialapp/src/pages/Profile.css
+++ b/socialapp/src/pages/Profile.css
@@ -37,14 +37,15 @@
     --bs-nav-tabs-link-active-bg: var(--dark-blue);
     --bs-nav-tabs-link-active-border-color: transparent;
     --bs-nav-tabs-link-active-color: var(--teal);
-    --bs-nav-link-hover-color: transparent;
+    --bs-nav-link-hover-color: var(--orange);
 }
 .profileContainer .nav-link {
     border-bottom-left-radius: 11px;
     border-bottom-right-radius: 11px; 
     border-top-right-radius: 0;   
     border-top-left-radius: 0;
-    background-color: var(--slightly-darker-blue);
+    background-color: var(--darker-blue);
+    color: var(--white-teal);
 }
 .profileContainer .nav-link:hover {
     outline: transparent;

--- a/socialapp/src/pages/StreamHome.jsx
+++ b/socialapp/src/pages/StreamHome.jsx
@@ -65,11 +65,11 @@ export default function StreamHome() {
               </button>
             }
             on="hover"
-            contentStyle={{ "background-color": "var(--dark-blue)", border: "none", width: "fit-content", padding: "0.5rem" }}
-            arrowStyle={{ "color": "var(--dark-blue)", stroke: "none"}}
+            contentStyle={{ backgroundColor: "var(--dark-blue)", border: "none", width: "fit-content", padding: "0.5rem" }}
+            arrowStyle={{ color: "var(--dark-blue)", stroke: "none"}}
             arrow={true}
           >
-            <span style={{ "font-size": "0.8rem" }}> Click to see GitHub activities! </span>
+            <span style={{ fontSize: "0.8rem" }}> Click to see GitHub activities! </span>
           </Popup>
         </Col>
       </Row>

--- a/socialapp/src/pages/StreamHome.jsx
+++ b/socialapp/src/pages/StreamHome.jsx
@@ -55,7 +55,7 @@ export default function StreamHome() {
               <button style={{ background: "none", border: "none" }}>
                 <BsGithub
                   style={{
-                    color: "white",
+                    color: "var(--white-teal)",
                     marginTop: "1em",
                     marginBottom: "1em",
                     marginRight: "1em",

--- a/socialapp/src/pages/StreamHome.jsx
+++ b/socialapp/src/pages/StreamHome.jsx
@@ -65,10 +65,11 @@ export default function StreamHome() {
               </button>
             }
             on="hover"
-            contentStyle={{ color: "black" }}
+            contentStyle={{ "background-color": "var(--dark-blue)", border: "none", width: "fit-content", padding: "0.5rem" }}
+            arrowStyle={{ "color": "var(--dark-blue)", stroke: "none"}}
             arrow={true}
           >
-            <span> Click to see github activities! </span>
+            <span style={{ "font-size": "0.8rem" }}> Click to see GitHub activities! </span>
           </Popup>
         </Col>
       </Row>


### PR DESCRIPTION
- Posts can now link to any public image link
- When clicking on a nav item in the sidebar and you're currently in the same page, it will "refresh" it.
- e.g. bruh creates a new friends post and current user is in inbox, then current user can click the inbox icon to "refresh" the inbox page to show the new friends post.
- Added a share button to card posts, so friend posts by other authors can be reshared to our friends.
  * If the post is a friends-only post, clicking the share button will reshare to our friends
  * For example, say we have author1, 2, and 3. Author 1 is friends with author 2 and 3, but author 2 is not friends with author 3. Author 2 creates a friends-only post, and author 1 recieves this post in their inbox. Author 3 does not have this post. But then author 1 shares author 2's friends-only post, which sends that post to author 3 since author 3 and 1 are friends.
  * If the post is a public post, clicking the share button will reshare to our followers
- Added a friends-only indicator to post card