### PR TITLE
Lotsa stuff

### DIFF
--- a/backend/author/admin.py
+++ b/backend/author/admin.py
@@ -31,8 +31,8 @@ class AuthorAdmin(UserAdmin):
     form = AuthorChangeForm
     model = Author
     # display the fields of the Author
-    list_display = ('displayName', 'uuid', 'id', 'is_staff', 'is_active')
-    list_filter = ('displayName', 'uuid', 'id', 'is_staff', 'is_active')
+    list_display = ('displayName', 'uuid', 'host', 'is_staff', 'is_active')
+    list_filter = ('displayName', 'uuid', 'host', 'is_staff', 'is_active')
     fieldsets = (
         (None, {'fields': ('displayName', 'password', 'profileImage', 'host', 'github', 'url', 'id', 'uuid', 'followers')}),
         ('Permissions', {'fields': ('is_staff', 'is_active', 'is_superuser')}),
@@ -43,7 +43,7 @@ class AuthorAdmin(UserAdmin):
             'fields': ('displayName', 'profileImage', 'host', 'github', 'password', 'is_staff', 'is_active')
         }),
     )
-
+    filter_horizontal = ('followers',)
     search_fields = ('displayName', 'uuid', 'id')
     ordering = ('displayName', 'uuid', 'id')
     readonly_fields = ('id', 'uuid')

--- a/backend/author/tests.py
+++ b/backend/author/tests.py
@@ -100,7 +100,7 @@ class AuthorsTestCase(TestCase):
 
         # shouldn't need authentication
         res = self.client.get(url, format="json")
-        numAuthors = len(res.data)
+        numAuthors = len(res.data.get("items"))
         self.assertEqual(res.status_code, 200)
         self.assertEqual(numAuthors, self.NUM_AUTHORS)
         self.assertEqual(res.data.get('type'), 'authors')

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -45,7 +45,7 @@ urlpatterns = [
 
 
     # Inbox Endpoints
-    path("service/authors/<str:author_id>/inbox/",include("inbox.urls"), name="get all post from inbox"),
+    path("service/authors/<str:author_id>/inbox",include("inbox.urls"), name="get all post from inbox"),
 
     # Like Endpoints
     path('service/authors/<str:author_id>/posts/<str:post_id>/likes', LikesPostApiView.as_view(), name="post like"),

--- a/backend/backend/utils.py
+++ b/backend/backend/utils.py
@@ -14,6 +14,7 @@ from django.contrib.auth.hashers import make_password
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from node.utils import authenticated_GET
+from uuid import uuid4
 
 def isUUID(val):
     try:
@@ -270,10 +271,14 @@ def create_remote_author(remote_author):
     
     remote_author["followers"] = []
     author_serializer = AuthorSerializer(data=remote_author)
+    remote_author_uuid = get_author_uuid_from_id(remote_author["id"])
+    if not isUUID(remote_author_uuid):
+        remote_author_uuid = uuid4()
 
+    console.log
     if author_serializer.is_valid():
         author_serializer.save(
-                uuid=get_author_uuid_from_id(remote_author["id"]),
+                uuid= remote_author_uuid,
                 id=remote_author.get("id"),
                 password=make_password(remote_author["displayName"]+"password")
                 )

--- a/backend/backend/utils.py
+++ b/backend/backend/utils.py
@@ -275,12 +275,12 @@ def create_remote_author(remote_author):
     if not isUUID(remote_author_uuid):
         remote_author_uuid = uuid4()
 
-    console.log
     if author_serializer.is_valid():
         author_serializer.save(
                 uuid= remote_author_uuid,
                 id=remote_author.get("id"),
-                password=make_password(remote_author["displayName"]+"password")
+                password=make_password(remote_author["displayName"]+"password"),
+                host= add_end_slash(remote_author.get("host"))
                 )
         
 def validate_remote_post(post):
@@ -407,7 +407,12 @@ def create_remote_like(remote_like):
             like_serializer.save(
                 author = remote_author_obj
             )
-    
+
+def remove_objects(node):
+    # removes the node's objects
+    node_host_split = node.host.split('/')
+    actual_host = node_host_split[0] + '://' + node_host_split[2] + '/'
+    Author.objects.filter(host=node.host).delete()
 
 def get_author_with_id(id_url):
     # returns None if author DNE

--- a/backend/comments/admin.py
+++ b/backend/comments/admin.py
@@ -1,5 +1,9 @@
 from django.contrib import admin
 from .models import Comment, CommentSrc
 
-admin.site.register(Comment)
+
+class CommentAdmin(admin.ModelAdmin):
+    list_display = ['comment', 'published', 'author']
+
+admin.site.register(Comment, CommentAdmin)
 admin.site.register(CommentSrc)

--- a/backend/inbox/admin.py
+++ b/backend/inbox/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from .models import Inbox
 
-# Register your models here.
-admin.site.register(Inbox)
+class InboxAdmin(admin.ModelAdmin):
+    filter_horizontal = ('posts', 'comments', 'likes', 'follow_requests',)
+
+admin.site.register(Inbox, InboxAdmin)

--- a/backend/inbox/urls.py
+++ b/backend/inbox/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from inbox import views
 
 urlpatterns = [
-    path("/", views.InboxApiView.as_view(), name="retrieving an inbox"),
+    path("", views.InboxApiView.as_view(), name="retrieving an inbox"),
     path("/all/", views.InboxAllApiView.as_view(), name="check if follow display in inbox"),
     path("/<str:foreign_author_id>/", views.InboxDeleteFRApiView.as_view(), name="delete follow request from author ID"),
 

--- a/backend/inbox/urls.py
+++ b/backend/inbox/urls.py
@@ -3,9 +3,9 @@ from django.urls import path
 from inbox import views
 
 urlpatterns = [
-    path("", views.InboxApiView.as_view(), name="retrieving an inbox"),
-    path("all/", views.InboxAllApiView.as_view(), name="check if follow display in inbox"),
-    path("<str:foreign_author_id>/", views.InboxDeleteFRApiView.as_view(), name="delete follow request from author ID"),
+    path("/", views.InboxApiView.as_view(), name="retrieving an inbox"),
+    path("/all/", views.InboxAllApiView.as_view(), name="check if follow display in inbox"),
+    path("/<str:foreign_author_id>/", views.InboxDeleteFRApiView.as_view(), name="delete follow request from author ID"),
 
 
 ]

--- a/backend/like/admin.py
+++ b/backend/like/admin.py
@@ -1,4 +1,16 @@
 from django.contrib import admin
 from .models import Like
 
-admin.site.register(Like)
+class LikeAdmin(admin.ModelAdmin):
+    list_display = ['summary', 'author', 'authors_host', 'like_object']
+
+    @admin.display(ordering="author__host", description="Author's Host")
+    def authors_host(self, obj):
+        return obj.author.host
+    
+    @admin.display(description="Object UUID Liked")
+    def like_object(self, obj):
+        return obj.object.split('posts/')[1]
+
+
+admin.site.register(Like, LikeAdmin)

--- a/backend/like/views.py
+++ b/backend/like/views.py
@@ -42,7 +42,7 @@ class LikesPostApiView(GenericAPIView):
                 return response.Response(result, status=status.HTTP_200_OK)
             else:
                 result = {"type": "likes", "items": []}
-                return response.Response(result, status=status.HTTP_200_OK)
+                return response.Response("You are neither a friend of the post's author nor the author, likes not shown.", status=status.HTTP_401_UNAUTHORIZED)
         except Exception as e:
             return response.Response(f"Error: {e}", status=status.HTTP_404_NOT_FOUND)
 

--- a/backend/like/views.py
+++ b/backend/like/views.py
@@ -128,6 +128,7 @@ class AuthorLikedApiView(GenericAPIView):
     """
     URL: ://service/authors/{AUTHOR_ID}/liked
     GET [local, remote] list what public things AUTHOR_ID liked.
+    POST [local] creates a like object
     It’s a list of of likes originating from this author
     Note: be careful here private information could be disclosed.
     """
@@ -136,9 +137,29 @@ class AuthorLikedApiView(GenericAPIView):
     def get(self, request, author_id):
         try:
             author = Author.objects.get(uuid = author_id)
-            post_like = Like.objects.filter(author = author)
-            post_likes = self.serializer_class(post_like, many=True)
-            result = {"type": "liked", "items": post_likes.data}
+            liked = Like.objects.filter(author = author)
+            liked_serializer = self.serializer_class(liked, many=True)
+            result = {"type": "liked", "items": liked_serializer.data}
             return response.Response(result, status=status.HTTP_200_OK)
+        except Exception as e:
+            return response.Response(f"Error: {e}", status=status.HTTP_404_NOT_FOUND)
+    
+    def post(self, request, author_id):
+        '''FOR LOCAL USE ONLY.'''
+        try:
+            if isAuthorized(request, author_id):
+                
+                author = Author.objects.get(uuid = author_id)
+                like_exists = Like.objects.filter(author = author,object = request.data["object"]).exists()
+                if like_exists:
+                    return response.Response("Like already exists", status=status.HTTP_400_BAD_REQUEST)
+                request.data["author"] = author
+                liked_serializer = self.serializer_class(data=request.data)
+                if liked_serializer.is_valid(raise_exception=True):
+                    liked_serializer.save(author=author)
+                return response.Response("Like created", status=status.HTTP_201_CREATED)
+            else:
+                return response.Response("You are not the author.", status=status.HTTP_401_UNAUTHORIZED)
+            
         except Exception as e:
             return response.Response(f"Error: {e}", status=status.HTTP_404_NOT_FOUND)

--- a/backend/node/admin.py
+++ b/backend/node/admin.py
@@ -13,9 +13,12 @@ from .models import Node
 def create_node_authors(modeladmin, request, queryset):
     all_remote_authors = list()
     for node in queryset:
-        res = getNodeRemoteAuthors(node)
-        all_remote_authors.extend(res)
-
+        try:
+            res = getNodeRemoteAuthors(node)
+            all_remote_authors.extend(res)
+        except Exception as e:
+            print("Failed to get nodes remote authors. ", e)
+    print(all_remote_authors)
     for remote_author in all_remote_authors:
         if not remote_author_exists(remote_author["id"]):
             try:

--- a/backend/node/admin.py
+++ b/backend/node/admin.py
@@ -3,7 +3,7 @@ from django.contrib.auth.hashers import make_password
 from backend.utils import (remote_author_exists, create_remote_like, 
 get_author_uuid_from_id, get_post_uuid_from_id, create_remote_post, 
     create_remote_comment, create_remote_author, get_comment_uuid_from_id,
-    validate_remote_post)
+    validate_remote_post, remove_objects)
 from author.serializers import AuthorSerializer
 from post.serializers import PostSerializer
 from comments.serializers import CommentsSerializer
@@ -96,8 +96,11 @@ def create_node_objects(modeladmin, request, queryset):
     create_node_posts(modeladmin, request, queryset)
     create_node_authors(modeladmin, request, queryset)
 
-
+def del_remote_node_objects(modeladmin, request, queryset):
+    # removes the node's objects
+    for node in queryset:
+        remove_objects(node)
 class NodeAdmin(admin.ModelAdmin):
-    actions = [create_node_authors, create_node_posts, create_node_objects]
+    actions = [create_node_authors, create_node_posts, create_node_objects, del_remote_node_objects]
 
 admin.site.register(Node, NodeAdmin)

--- a/backend/node/utils.py
+++ b/backend/node/utils.py
@@ -35,6 +35,7 @@ def getNodeRemoteAuthors(node):
 
     node_authors_endpoint = f"{node.host}authors/"
     res = authenticated_GET(node_authors_endpoint, node)
+    print(f"getNodeRemoteAuthors: Failed with res {res.status_code}:{res.content}")
     if (res.status_code == 200):
         return res.json()["items"]
     else:

--- a/backend/post/admin.py
+++ b/backend/post/admin.py
@@ -1,6 +1,11 @@
 from django.contrib import admin
-
-# Register your models here.
 from .models import Post
 
-admin.site.register(Post)
+class PostAdmin(admin.ModelAdmin):
+    list_display = ['title', 'published', 'author', 'authors_host']
+
+    @admin.display(ordering="author__host", description="Author's Host")
+    def authors_host(self, obj):
+        return obj.author.host
+
+admin.site.register(Post, PostAdmin)

--- a/backend/post/tests.py
+++ b/backend/post/tests.py
@@ -136,6 +136,16 @@ class PostTestCase(APITestCase):
         self.assertEqual(self.mock_post_1['unlisted'], post_data['unlisted'])
         self.assertEqual(self.mock_post_1['categories'], post_data['categories'])
 
+    def test_get_posts_pagination(self):
+        request = self.mock_post_1
+        response = self.client.post(f'/service/authors/{self.author_id}/posts/', request, format="json")
+        self.assertEqual(response.status_code, 201)
+        response = self.client.post(f'/service/authors/{self.author_id}/posts/', request, format="json")
+        self.assertEqual(response.status_code, 201)
+        post_id =response.data['uuid']
+        response = self.client.get(f'/service/authors/{self.author_id}/posts/?page=1&size=1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data.get("items")), 1)
 
     def test_put_posts(self):
         """

--- a/socialapp/src/components/Posts/ExplorePostCard.css
+++ b/socialapp/src/components/Posts/ExplorePostCard.css
@@ -38,6 +38,10 @@
     color: var(--teal);
 }
 
+.post-card-explore .profile-pic-post:hover {
+    cursor: pointer;
+}
+
 .post-card-explore .post-author-name {
     display: inline-flex;
     align-items: center;

--- a/socialapp/src/components/Posts/ExplorePostCard.css
+++ b/socialapp/src/components/Posts/ExplorePostCard.css
@@ -6,7 +6,8 @@
     margin-left: 10px;
     border-color: none;
     --bs-card-bg: none;
-    flex-basis: 16.4rem;
+    flex-basis: 14.2rem;
+    flex-grow: 0;
 }
 
 .post-card-explore .card-header {

--- a/socialapp/src/components/Posts/ExplorePostCard.jsx
+++ b/socialapp/src/components/Posts/ExplorePostCard.jsx
@@ -92,7 +92,7 @@ export default function PostCard(props) {
         await api
         .get(`${baseURL}/node/?host=${author.host}`)
         .then((response) => {
-          let node = createNodeObject(response, author.host);
+          let node = createNodeObject(response, author);
           setPostAuthorNode(node);
           setPostAuthorBaseAPI(node.host);
         })
@@ -140,7 +140,7 @@ export default function PostCard(props) {
       api
         .get(`${baseURL}/node/?host=${author.host}`)
         .then((response) => {
-          let node = createNodeObject(response, author.host);
+          let node = createNodeObject(response, author);
           api
             .post(`${node.host}authors/${extractAuthorUUID(author.id)}/inbox}`, { header: node.headers }, post)
             .then((response) => {

--- a/socialapp/src/components/Posts/ExplorePostCard.jsx
+++ b/socialapp/src/components/Posts/ExplorePostCard.jsx
@@ -73,26 +73,30 @@ export default function PostCard(props) {
       .then((response) => {
         setLiked(true);
         setLikeCount((likeCount) => likeCount + 1);
+
+        // Need this for checking if author liked remote post or not.
+        // Since when sending a like object to remote host's inbox,
+        // the like object is created in their DB but not ours. So 
+        // create a like object in ours as well.
+        api
+          .post(`${baseURL}/authors/${loggedInUser.uuid}/liked`, postLike)
+          .catch((error) => {
+            console.log("Failed to create backup like object", error.response.data);
+          });
       })
       .catch((error) => {
         console.log("Failed to send like to inbox", error.response);
-        // also create like object in our local if things go wrong in remote
-        api
-        .post(`${baseURL}/authors/${loggedInUser.uuid}/liked`, postLike)
-        .catch((error) => {
-          console.log(error.response.data);
-        });
       });
   };
 
   useEffect(() => {
     if (!authorHostIsOurs(props.post.author.host)) {
-      const fetchNode = async (author) => {
+      const fetchNode = async () => {
         // fetches the node object
         await api
-        .get(`${baseURL}/node/?host=${author.host}`)
+        .get(`${baseURL}/node/?host=${props.post.author.host}`)
         .then((response) => {
-          let node = createNodeObject(response, author);
+          let node = createNodeObject(response, props.post.author);
           setPostAuthorNode(node);
           setPostAuthorBaseAPI(node.host);
         })

--- a/socialapp/src/components/Posts/PostCard.css
+++ b/socialapp/src/components/Posts/PostCard.css
@@ -149,12 +149,15 @@
 .post-card .input-comment {
     width: 100%;
     margin-top: 1rem;
+    display: grid;
+    grid-template-columns: 11fr 1fr;
 }
 
 .post-card .input-comment .form-control {
     background-color: var(--slightly-darker-blue);
     box-shadow: none;
-    border-radius: 2rem;
+    border-top-left-radius: 2rem;
+    border-bottom-left-radius: 2rem;
 }
 
 .post-card .input-comment .form-control:focus {

--- a/socialapp/src/components/Posts/PostCard.jsx
+++ b/socialapp/src/components/Posts/PostCard.jsx
@@ -148,7 +148,7 @@ export default function PostCard(props) {
       node.headers = {}
       fetchPostAuthorData(baseURL+'/', node);
     }
-  }, [postAuthorNode])
+  }, [postAuthorNode, useLocation().state])
 
   const fetchNode = async (author) => {
     // fetches the node object

--- a/socialapp/src/components/Posts/PostCard.jsx
+++ b/socialapp/src/components/Posts/PostCard.jsx
@@ -164,65 +164,45 @@ export default function PostCard(props) {
     }
   }, []);
 
+  const sendPostToAuthorInbox = (author, post) => {
+    if (!authorHostIsOurs(author.host)) {
+      api
+        .get(`${baseURL}/node/?host=${author.host}`)
+        .then((response) => {
+          let node = createNodeObject(response, author.host);
+          api
+            .post(`${node.host}authors/${extractAuthorUUID(author.id)}/inbox}`, { header: node.headers }, post)
+            .then((response) => {
+              console.log("Success sending to author's inbox", response);
+            })
+            .catch((error) => {
+              console.log("Failed to send post to inbox of author", error.response);
+            });
+      });
+    } else {
+      api
+        .post(`${baseURL}/authors/${extractAuthorUUID(author.id)}/inbox}`, post)
+        .then((response) => {
+          console.log("Success sending to author's inbox", response);
+        })
+        .catch((error) => {
+          console.log("Failed to send post to inbox of author", error.response);
+        });
+    }
+  }
+
   const sharePost = (post) => {
-    let host = baseURL + '/';
     if (post.visibility === "PUBLIC") {
       for (let index = 0; index < followers.length; index++) {
-        const follower = followers[index]
-        if (!authorHostIsOurs(follower.host)) {
-          api
-            .get(`${baseURL}/node/?host=${follower.host}`)
-            .then((response) => {
-              let node = createNodeObject(response, follower.host);
-              api
-                .post(`${node.host}authors/${extractAuthorUUID(follower.id)}/inbox/}`, { header: node.headers }, post)
-                .then((response) => {
-                  console.log(response);
-                })
-                .catch((error) => {
-                  console.log("Failed to get posts of author. " + error);
-                });
-          });
-        } else {
-          api
-            .post(`${host}authors/${extractAuthorUUID(loggedInUser.id)}/inbox/}`, post)
-            .then((response) => {
-              console.log(response);
-            })
-            .catch((error) => {
-              console.log("Failed to get posts of author. " + error);
-            });
-        }
-      }
+        const follower = followers[index];
+        sendPostToAuthorInbox(follower, post);
+      };
     } else if (post.visibility === "FRIENDS") {
       for (let index = 0; index < friends.length; index++) {
-        const friend = friends[index]
-        if (!authorHostIsOurs(friend.host)) {
-          api
-            .get(`${baseURL}/node/?host=${friend.host}`)
-            .then((response) => {
-              let node = createNodeObject(response, friend.host);
-              api
-                .post(`${node.host}authors/${extractAuthorUUID(friend.id)}/inbox/}`, { header: node.headers }, post)
-                .then((response) => {
-                  console.log(response);
-                })
-                .catch((error) => {
-                  console.log("Failed to get posts of author. " + error);
-                });
-            });
-        } else {
-          api
-            .post(`${host}authors/${extractAuthorUUID(loggedInUser.id)}/inbox/}`, post)
-            .then((response) => {
-              console.log(response);
-            })
-            .catch((error) => {
-              console.log("Failed to get posts of author. " + error);
-            });
-        }
-      }
-    }
+        const friend = friends[index];
+        sendPostToAuthorInbox(friend, post);
+      };
+    };
   };
 
   const deletePost = (uuid) => {

--- a/socialapp/src/components/Posts/PostCard.jsx
+++ b/socialapp/src/components/Posts/PostCard.jsx
@@ -282,11 +282,12 @@ export default function PostCard(props) {
       });
   }
 
-  const sendComment = (uuid) => {
+  const sendComment = (e) => {
+    e.preventDefault();
     var commentObject = {};
     api
       .post(
-        `${baseURL}/authors/${extractAuthorUUID(props.post.author.id)}/posts/${uuid}/comments/`,
+        `${baseURL}/authors/${extractAuthorUUID(props.post.author.id)}/posts/${post_id}/comments/`,
         postComment
       )
       .then((response) => {
@@ -305,7 +306,8 @@ export default function PostCard(props) {
         } else {
           sendCommentToInbox(baseURL+'/', post_user_uuid, commentObject, emptyNode);
         }
-
+        setPostComment({ ...postComment, comment: "" });
+        e.target.reset();
         refreshState();
       })
       .catch((error) => {
@@ -499,27 +501,26 @@ export default function PostCard(props) {
           ) : null}
         </div>
         <div className="comments-container">
-          <div className="input-comment">
-            <InputGroup className="mb-3">
-              <Form.Control
-                placeholder="Comment"
-                aria-label="Comment"
-                onChange={(e) =>
-                  setPostComment({ ...postComment, comment: e.target.value })
-                }
-              />
-              <Button
-                style={{
-                  borderRadius: "1.5rem",
-                  color: "black",
-                  backgroundColor: "#BFEFE9",
-                }}
-                onClick={() => sendComment(post_id)}
+          <Form className="input-comment mb-3" onSubmit={sendComment}>
+            <Form.Control
+              placeholder="Comment"
+              aria-label="Comment"
+              onChange={(e) =>
+                setPostComment({ ...postComment, comment: e.target.value })
+              }
+            >
+            </Form.Control>
+            <Button
+              style={{
+                borderRadius: "1.5rem",
+                color: "black",
+                backgroundColor: "#BFEFE9",
+              }}
+              type="submit"
               >
                 Send
               </Button>
-            </InputGroup>
-          </div>
+          </Form>
         </div>
       </Card.Body>
     </Card>

--- a/socialapp/src/components/Posts/PostCard.jsx
+++ b/socialapp/src/components/Posts/PostCard.jsx
@@ -133,9 +133,9 @@ export default function PostCard(props) {
       })
       .catch((error) => {
         console.log(error);
-        // TODO: If failed to fetch from theirs, fall back on ours?
       });
     }
+
     if (!authorHostIsOurs(props.post.author.host) && postAuthorNode !== null) {
       fetchPostAuthorData(postAuthorBaseApiURL, postAuthorNode);
     } else {
@@ -151,7 +151,7 @@ export default function PostCard(props) {
         await api
         .get(`${baseURL}/node/?host=${author.host}`)
         .then((response) => {
-          let node = createNodeObject(response, author.host);
+          let node = createNodeObject(response, author);
           setPostAuthorNode(node);
           setPostAuthorBaseAPI(node.host);
         })
@@ -199,7 +199,7 @@ export default function PostCard(props) {
       api
         .get(`${baseURL}/node/?host=${author.host}`)
         .then((response) => {
-          let node = createNodeObject(response, author.host);
+          let node = createNodeObject(response, author);
           api
             .post(`${node.host}authors/${extractAuthorUUID(author.id)}/inbox}`, { header: node.headers }, post)
             .then((response) => {

--- a/socialapp/src/components/Profile/EditProfileButton.jsx
+++ b/socialapp/src/components/Profile/EditProfileButton.jsx
@@ -59,6 +59,7 @@ function VerticallyCenteredModal(props) {
               .post(`${baseURL}/authors/${props.author.uuid}/`, toSend)
               .then((response) => {
                 if (response.status === 202) {
+                  localStorage.setItem("loggedInUser", response.data.user);
                   props.onHide();
                   window.location.reload(); // refreshes page...not ideal.
                 }

--- a/socialapp/src/components/Profile/EditProfileButton.jsx
+++ b/socialapp/src/components/Profile/EditProfileButton.jsx
@@ -59,7 +59,7 @@ function VerticallyCenteredModal(props) {
               .post(`${baseURL}/authors/${props.author.uuid}/`, toSend)
               .then((response) => {
                 if (response.status === 202) {
-                  localStorage.setItem("loggedInUser", response.data.user);
+                  localStorage.setItem("loggedInUser", JSON.stringify(response.data.user));
                   props.onHide();
                   window.location.reload(); // refreshes page...not ideal.
                 }

--- a/socialapp/src/components/Profile/FollowButton.jsx
+++ b/socialapp/src/components/Profile/FollowButton.jsx
@@ -67,7 +67,7 @@ export default function FollowButton(props) {
       setFollowState("followSent");
       // Send a friend request object to the inbox of the author we're viewing
       api
-        .post(`${props.authorBaseApiURL}authors/${author_id}/inbox/`, {
+        .post(`${props.authorBaseApiURL}authors/${author_id}/inbox`, {
           type: "follow",
           summary: `${currentAuthor.displayName} wants to follow ${props.authorViewing.displayName}`,
           actor: currentAuthor,

--- a/socialapp/src/components/Profile/FollowButton.jsx
+++ b/socialapp/src/components/Profile/FollowButton.jsx
@@ -3,7 +3,7 @@ import Button from "react-bootstrap/Button";
 import AuthContext from "../../context/AuthContext";
 import useAxios from "../../utils/useAxios";
 import { useParams, useLocation } from "react-router-dom";
-import { authorHostIsOurs, extractAuthorUUID } from "../../utils/utils";
+import { authorHostIsOurs, emptyNode } from "../../utils/utils";
 
 // function authorInArray(id, array) {
 //   // checks if the given author id is in the array
@@ -36,37 +36,30 @@ export default function FollowButton(props) {
   }, [isNotCurrentUser, useLocation().state]);
 
   useEffect(() => {
-    const following = async () => {
-      if (!authorHostIsOurs(props.authorViewing.host) && props.authorBaseApiURL !== null) {
-        await api
-          .post(`${props.authorBaseApiURL}authors/${author_id}/followers/${currentAuthor.uuid}`, { header: props.authorNode.headers })
-          .then((response) => {
-            if (response.data) {
-              setIsFollowing(response.data);
-              setFollowState("following");
-            } else {
-              setFollowState("notFollowing");
-            }
-          });
-      } else {
-        await api
-          .get(`${baseURL}/authors/${author_id}/followers/${currentAuthor.uuid}`)
-          .then((response) => {
-            if (response.data) {
-              setIsFollowing(response.data);
-              setFollowState("following");
-            } else {
-              setFollowState("notFollowing");
-            }
-          })
-          .catch((error) => {
-            console.log(
-              "Failed to get check if current author is following " + error
-            );
-          });
-      }
+    const following = async (ApiURL, node) => {
+      await api
+        .get(`${ApiURL}authors/${author_id}/followers/${currentAuthor.uuid}`,
+         { header: node.headers }
+        )
+        .then((response) => {
+          if (response.data) {
+            setIsFollowing(response.data);
+            setFollowState("following");
+          } else {
+            setFollowState("notFollowing");
+          }
+        })
+        .catch((error) =>{
+          console.log(
+            "Failed to get check if current author is following ", error.response
+          );
+        })
     };
-    following();
+    if (!authorHostIsOurs(props.authorViewing.host) && props.authorBaseApiURL !== null) {
+      following(props.authorBaseApiURL, props.authorNode);
+    } else {
+      following(baseURL+'/', emptyNode);
+    }
   }, [isFollowing, useLocation().state]);
 
   const handleClick = () => {

--- a/socialapp/src/context/AuthContext.jsx
+++ b/socialapp/src/context/AuthContext.jsx
@@ -40,7 +40,7 @@ export const AuthProvider = ({ children }) => {
         setAuthTokens(data);
         setUser(jwt_decode(data.access));
         localStorage.setItem("authTokens", JSON.stringify(data));
-        localStorage.setItem("loggedInUser", data.user);
+        localStorage.setItem("loggedInUser", JSON.stringify(data.user));
         setLoginLoading(false);
       } else {
         alert("ERROR: " + data);

--- a/socialapp/src/context/AuthContext.jsx
+++ b/socialapp/src/context/AuthContext.jsx
@@ -40,6 +40,7 @@ export const AuthProvider = ({ children }) => {
         setAuthTokens(data);
         setUser(jwt_decode(data.access));
         localStorage.setItem("authTokens", JSON.stringify(data));
+        localStorage.setItem("loggedInUser", data.user);
         setLoginLoading(false);
       } else {
         alert("ERROR: " + data);

--- a/socialapp/src/pages/Explore.jsx
+++ b/socialapp/src/pages/Explore.jsx
@@ -63,9 +63,13 @@ export default function Explore() {
   const api = useAxios();
   const { baseURL } = useContext(AuthContext);
   const [remoteAuthors, setRemoteAuthors] = useState([]);
+  const [followers, setFollowers] = useState([]);
+  const [friends, setFriends] = useState([]);
+  const user_id = localStorage.getItem("user_id"); // the currently logged in author
 
   useEffect(() => {
-    api
+    const fetchData = async () => {
+      api
       .get(`${baseURL}/posts/`)
       .then((response) => {
         setPostsArray(response.data.items);
@@ -73,17 +77,36 @@ export default function Explore() {
       .catch((error) => {
         console.log(error);
       });
+      api
+        .get(`${baseURL}/node/authors/`)
+        .then((response) => {
+          setRemoteAuthors(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+      await api
+        .get(`${baseURL}/authors/${user_id}/followers`)
+        .then((response) => {
+          setFollowers(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+      await api
+        .get(`${baseURL}/authors/${user_id}/friends/`)
+        .then((response) => {
+          setFriends(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    }
+    fetchData();
   }, [useLocation().state]);
 
   useEffect(() => {
-    api
-      .get(`${baseURL}/node/authors/`)
-      .then((response) => {
-        setRemoteAuthors(response.data.items);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
+
   }, []);
 
   const search = async (val) => {
@@ -156,7 +179,7 @@ export default function Explore() {
                   <Row>
                     {searchPostsArray.map((post) => (
                       <Col key={post.id} >
-                        <ExplorePostCard post={post} />
+                        <ExplorePostCard loggedInAuthorsFollowers={followers} loggedInAuthorsFriends={friends} post={post} />
                       </Col>
                     ))}
                   </Row>
@@ -169,7 +192,7 @@ export default function Explore() {
                 <h5>Current public posts</h5>
                 <div className="all-posts-container">
                   {postsArray.map((post) => (
-                      <ExplorePostCard post={post} />
+                      <ExplorePostCard loggedInAuthorsFollowers={followers} loggedInAuthorsFriends={friends} post={post} key={post.id} />
                   ))}
                 </div>
               </>

--- a/socialapp/src/pages/Inbox.jsx
+++ b/socialapp/src/pages/Inbox.jsx
@@ -121,7 +121,7 @@ export default function Inbox() {
   
   const deleteInbox = () => {
     api
-      .delete(`${baseURL}/authors/${user_id}/inbox/`)
+      .delete(`${baseURL}/authors/${user_id}/inbox`)
       .then(
         (response) => setShow(true),
         setPosts([]),

--- a/socialapp/src/pages/Inbox.jsx
+++ b/socialapp/src/pages/Inbox.jsx
@@ -30,6 +30,8 @@ export default function Inbox() {
   const [comments, setComments] = useState([]);
   const { baseURL } = useContext(AuthContext); // our api url http://127.0.0.1/service
   const user_id = localStorage.getItem("user_id"); // the currently logged in author
+  const [followers, setFollowers] = useState([]);
+  const [friends, setFriends] = useState([]);
   const api = useAxios();
   const [show, setShow] = useState(false);
 
@@ -79,6 +81,22 @@ export default function Inbox() {
         })
         .catch((error) => {
           console.log("Failed to get inbox of author. " + error);
+        });
+      await api
+        .get(`${baseURL}/authors/${user_id}/followers`)
+        .then((response) => {
+          setFollowers(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+      await api
+        .get(`${baseURL}/authors/${user_id}/friends/`)
+        .then((response) => {
+          setFriends(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
         });
     };
     fetchData();
@@ -183,7 +201,7 @@ export default function Inbox() {
                 <Tab.Pane eventKey="post">
                   {typeof posts !== "undefined" ? (
                     posts.length !== 0 ? (
-                      posts.map((item, i) => <PostCard post={item} key={i}/>)
+                      posts.map((item, i) => <PostCard loggedInAuthorsFollowers={followers} loggedInAuthorsFriends={friends} post={item} key={i}/>)
                     ) : (
                       <h4>No posts yet! </h4>
                     )

--- a/socialapp/src/pages/Profile.css
+++ b/socialapp/src/pages/Profile.css
@@ -146,7 +146,7 @@ span {
 }
 
 .posts-container-profile .post-card {
-    margin-top: -6rem;
+    margin-top: -2rem;
     width: auto !important;
     scale: 0.8;
 }

--- a/socialapp/src/pages/Profile.jsx
+++ b/socialapp/src/pages/Profile.jsx
@@ -112,7 +112,7 @@ export default function Profile() {
     await api
     .get(`${baseURL}/node/?host=${author.host}`)
     .then((response) => {
-      let node = createNodeObject(response, author.host);
+      let node = createNodeObject(response, author);
       setAuthorNode(node);
       setAuthorBaseAPI(node.host);
     })

--- a/socialapp/src/pages/Profile.jsx
+++ b/socialapp/src/pages/Profile.jsx
@@ -10,7 +10,7 @@ import UserCard from "../components/UserCard";
 import EditProfileButton from "../components/Profile/EditProfileButton";
 import FollowButton from "../components/Profile/FollowButton";
 import ProfileTabs from "../components/Profile/ProfileTabs";
-import { authorHostIsOurs, removeDashes, createNodeObject } from '../utils/utils';
+import { authorHostIsOurs, removeDashes, createNodeObject, emptyNode } from '../utils/utils';
 import { CgRemote } from "react-icons/cg";
 
 function ProfilePosts(props) {
@@ -99,10 +99,10 @@ export default function Profile() {
 
   // Called after rendering. Fetches data
   useEffect(() => {
-    const fetchData = async (ApiURL, authorId) => {
+    const fetchData = async (ApiURL, authorId, node) => {
       await api      
         .get(`${ApiURL}authors/${authorId}/posts`,
-        {headers: authorNode.headers}
+        {headers: node.headers}
         )
         .then((response) => {
           setPostsArray(response.data);
@@ -112,7 +112,7 @@ export default function Profile() {
         });
       await api      
         .get(`${ApiURL}authors/${authorId}/followers`,
-        {headers: authorNode.headers}
+        {headers: node.headers}
         )
         .then((response) => {
           setFollowersArray(response.data);
@@ -123,7 +123,7 @@ export default function Profile() {
         });
       await api      
         .get(`${ApiURL}authors/${authorId}/friends`,
-        {headers: authorNode.headers}
+        {headers: node.headers}
         )
         .then((response) => {
           setFriendsArray(response.data);
@@ -133,11 +133,11 @@ export default function Profile() {
         });
     };
       if (!authorHostIsOurs(author.host) && authorBaseApiURL !== null) {
-        fetchData(authorBaseApiURL, removeDashes(author_id));
+        fetchData(authorBaseApiURL, removeDashes(author_id), authorNode);
       } else {
         // if the author is from our host, fetch from our API, or if something went wrong
         // trying to fetch the foreign author, then fetch that author from ours as backup.
-        fetchData(baseURL+'/', author_id);
+        fetchData(baseURL+'/', author_id, emptyNode);
       }
       
 
@@ -150,7 +150,11 @@ export default function Profile() {
           <div className="profilePicPage">
             <img id="profilePicPage" src={author.profileImage} alt="profilePic"/>
           </div>
-          <FollowButton authorViewing={author} authorNode={authorNode} authorBaseApiURL={authorBaseApiURL} />
+          <FollowButton 
+            authorViewing={author} 
+            authorNode={!authorHostIsOurs(author.host) ? authorNode : emptyNode} 
+            authorBaseApiURL={!authorHostIsOurs(author.host) ? authorBaseApiURL : baseURL+'/'} 
+          />
         </div>
 
         <div className="profileInfo">

--- a/socialapp/src/pages/Profile.jsx
+++ b/socialapp/src/pages/Profile.jsx
@@ -18,7 +18,7 @@ function ProfilePosts(props) {
     <div className="posts-container-profile">
     {
       typeof props.postsArray.items !== 'undefined' ? 
-        props.postsArray.items.map((post) => <PostCard post={post} key={post.id}/>)
+        props.postsArray.items.map((post) => <PostCard loggedInAuthorsFriends={props.loggedInAuthorsFriends} loggedInAuthorsFollowers={props.loggedInAuthorsFollowers} post={post} key={post.id}/>)
         : null
     }
     </div>
@@ -50,10 +50,13 @@ function ProfileFriends(props) {
 }
 
 export default function Profile() {
+  const loggedInUser = JSON.parse(localStorage.getItem("loggedInUser"));
   const [author, setAuthor] = useState("");               // the response object we get (Author object)  
   const [postsArray, setPostsArray] = useState(""); 
   const [followersArray, setFollowersArray] = useState(""); 
   const [friendsArray, setFriendsArray] = useState(""); 
+  const [loggedInAuthorsFollowers, setLoggedInAuthorsFollowers] = useState([]); 
+  const [loggedInAuthorsFriends, setLoggedInAuthorsFriends] = useState([]); 
   const { baseURL } = useContext(AuthContext);      // our api url http://127.0.0.1/service
   const { author_id, dir } = useParams();                       // gets the author id in the url
   const api = useAxios();
@@ -62,6 +65,27 @@ export default function Profile() {
   const [authorNode, setAuthorNode] = useState(null);     // the node object of post's author
   const [authorBaseApiURL, setAuthorBaseAPI] = useState(null);
 
+  useEffect(() => {
+    const fetchData = async () => {
+      await api
+        .get(`${baseURL}/authors/${loggedInUser.uuid}/followers`)
+        .then((response) => {
+          setLoggedInAuthorsFollowers(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+      await api
+        .get(`${baseURL}/authors/${loggedInUser.uuid}/friends/`)
+        .then((response) => {
+          setLoggedInAuthorsFriends(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    };
+    fetchData();
+  }, []);
 
   useEffect(() => {
     // first fetch the author
@@ -178,7 +202,7 @@ export default function Profile() {
         </div>
       </div>
       <ProfileTabs dir={dir} author_id={author_id}/>
-      {dir === 'posts' || dir === undefined ? <ProfilePosts postsArray={postsArray}/> : <></>}
+      {dir === 'posts' || dir === undefined ? <ProfilePosts loggedInAuthorsFollowers={loggedInAuthorsFollowers} loggedInAuthorsFriends={loggedInAuthorsFriends} postsArray={postsArray}/> : <></>}
       {dir === 'followers' ? <ProfileFollowers followersArray={followersArray}/> : <></>}
       {dir === 'friends' ? <ProfileFriends friendsArray={friendsArray}/> : <></>}
 

--- a/socialapp/src/pages/StreamHome.jsx
+++ b/socialapp/src/pages/StreamHome.jsx
@@ -14,6 +14,8 @@ import { useNavigate, useLocation } from "react-router-dom";
 export default function StreamHome() {
   const { baseURL } = useContext(AuthContext); // our api url http://127.0.0.1/service
   const [postsArray, setPostsArray] = useState([]);
+  const [followers, setFollowers] = useState([]);
+  const [friends, setFriends] = useState([]);
   const user_id = localStorage.getItem("user_id");
   const api = useAxios();
   const navigate = useNavigate();
@@ -43,6 +45,28 @@ export default function StreamHome() {
     };
     fetchData();
   }, [useLocation().state]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      await api
+        .get(`${baseURL}/authors/${user_id}/followers`)
+        .then((response) => {
+          setFollowers(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+      await api
+        .get(`${baseURL}/authors/${user_id}/friends/`)
+        .then((response) => {
+          setFriends(response.data.items);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    };
+    fetchData();
+  }, []);
 
   return (
     /**
@@ -83,7 +107,7 @@ export default function StreamHome() {
       <Container style={{ zIndex: 10 }}>
         <div className="posts">
           {postsArray.map((post) => (
-            <PostCard post={post} key={post.id} />
+            <PostCard loggedInAuthorsFollowers={followers} loggedInAuthorsFriends={friends} post={post} key={post.id} />
           ))}
         </div>
       </Container>

--- a/socialapp/src/utils/utils.js
+++ b/socialapp/src/utils/utils.js
@@ -59,3 +59,5 @@ export function isValidHTTPUrl(string) {
       }
     return url.protocol === "http:" || url.protocol === "https:";
 }
+
+export const emptyNode = {headers: {}};

--- a/socialapp/src/utils/utils.js
+++ b/socialapp/src/utils/utils.js
@@ -32,15 +32,16 @@ export function b64EncodeCredentials(username, password) {
     return b64Credentials;
 }
 
-export function createNodeObject(response, authorsHost) {
+export function createNodeObject(response, author) {
     // given a response object from GETting to the /node/ 
     // endpoint and the author's host field,
     // creates the node object with the authorization headers
     let node = {...response.data, headers:{}};
-    if (!authorHostIsOurs(authorsHost)) {
+    if (!authorHostIsOurs(author.host)) {
       // Post author's host is a remote host (not ours), add in HTTP Basic auth
       const authHeader = `Basic ${b64EncodeCredentials(response.data.username, response.data.password)}`;
       node = {...node, headers: {'Authorization': authHeader}};
+      // TODO: Add 'Request-Author': author.id to headers later
     }
     
     return node;


### PR DESCRIPTION
- Removed slash from inbox urls...because Team 2 doesn't use a slash.
- Have to be careful about Team 16's ids. They don't use UUID, so I've added a quick check for create_remote_author, but this needs to be done for posts and comments as well.
- Frontend now has `loggedInUser` which contains info about the logged in user's author. See how it's retrieved in PostCard.jsx.
- Overhauled PostCard.jsx and ExplorePostCard.jsx to be more efficient; There are now less API calls for each post card, and really the only API calls for them when the page is first loaded is to the post/likes/ and post/comments endpoints. Before it would call /followers/ and /friends/ for EACH post, which was redundant because these two calls were only for the logged in user.
- Changed how liked is determined; Instead of looping through the likes of a post, check the current author's /liked/ endpoint instead. This is because it's not guaranteed that the /likes/ response will contain all the likes of the post (public posts won't show who liked the post, so the response would be an empty list)
- There could be possible issues with going this way, but it seems to work for now. 